### PR TITLE
tolerate errors when migrating parts, and allow migrating the rest and logging failures

### DIFF
--- a/decisions/1708990672-enable-users-to-migrate-tolerating-errors.md
+++ b/decisions/1708990672-enable-users-to-migrate-tolerating-errors.md
@@ -1,0 +1,53 @@
+# enable users to migrate tolerating errors
+
+Authors
+* [bengo](https://bengo.is)
+
+## Context
+
+We are trying to enable this user story:
+* As a user of old.web3.storage who wants to migrate to w3 up, I can use migrate-to-w3up to migrate all my uploads from old.web3.storage to a w3up space, so I can stop using old.web3.storage but still expect all my old uploads to be available on IPFS.
+
+To some extent we have, but it leaves a lot of room for improvement in really big migration runs. For example, I have been testing an account with more than $370k uploads. This means at least that many invocations, and at that scale we're likely to face 'normal errors' that we may not be able to rely on avoiding alltogether.
+
+When these errors happen now, the migration process halts due to an unexpected error. This means when you do a big migration run an encounter a 'normal error', you may not find out for a couple hours, then see the error later, and there isn't a way to continue migrating from the last upload that worked.
+
+## Decision
+
+### Requirement 1
+
+`migrate-to-w3up` MUST be able to run a migration of an old.web3.storage account in such a way that, when encountering an error, the migration process tolerates it, logs the error, and moves on to attempting migration of the rest of the uploads.
+
+These logs will include
+* migration run start datetime
+* migration run stop datetime
+* log for any source uploads that could not be migrated (e.g. due to intermittent network failure)
+
+Rationale: This will make it possible for any users of `migrate-to-w3up` to kick off migration of a huge old.web3.storage account, check back over time on progress, and when the process ends, be able to report on how many of the source uploads were migrated, how many failed to be migrated, and the cause of any failure.
+
+### Requirement 2
+
+`migrate-to-w3up` must show a progress indicator for migrations of old.web3.storage accounts.
+
+Rationale: this makes it explicit how to understand how long the migration might take, whether it's stuck, etc. Without this it's almost impossible to set expectations for duration of a migration run.
+
+### Ideation
+
+Example invocation after this change:
+```shell
+# (with WEB3_TOKEN env var set which selects source uploads)
+# note stderr is redirected
+⚡️ migration=w3up-migration-$(date +%s); migrate-to-w3up --space <space.did> --log-failures /tmp/$migration.failures.ndjson
+# terminal would show progress and any errors
+# migration failures will be appended to /tmp/$migration.failures.ndjson
+```
+
+`migrate-to-w3up` SHOULD be able to run a second migration pass to retry all failed uploads using only the log file `/tmp/$migration.failures.ndjson`
+
+## Implementation
+
+* https://github.com/web3-storage/migrate-to-w3up/pull/6
+
+## Changelog
+
+* 2024-02-26: initial draft of this document

--- a/migrate-to-w3up.js
+++ b/migrate-to-w3up.js
@@ -285,9 +285,6 @@ async function migratePartCli(spaceDid, args) {
  * @param {any} value - json property value
  */
 function stringifyForMigrationProgressStdio(key, value) {
-  if (key === 'receipt' && value) {
-    return receiptToJson(value)
-  }
   if (value instanceof Map) {
     return Object.fromEntries(value.entries())
   }

--- a/migrate-to-w3up.js
+++ b/migrate-to-w3up.js
@@ -222,9 +222,6 @@ async function main(argv) {
       const consoleLink = `https://console.web3.storage/space/${space}/root/${root}`
       if (ui) {
         ui?.log.write(consoleLink)
-      } else if (!ndJsonLog) {
-        // if no ui, and no explicit logfile, log to stdout
-        console.log(JSON.stringify(event, stringifyForMigrationProgressStdio, isInteractive ? 2 : undefined))
       }
     }
     ui?.updateBottomBar(getProgressMessage())
@@ -232,6 +229,8 @@ async function main(argv) {
   if (uploadMigrationFailureCount) {
     console.warn(`failed to migrate ${uploadMigrationFailureCount}/${uploadMigrationSuccessCount+uploadMigrationFailureCount} uploads`)
     process.exit(1)
+  } else {
+    console.warn(`migrated ${uploadMigrationSuccessCount+uploadMigrationFailureCount} uploads`)
   }
 }
 

--- a/migrate-to-w3up.test.js
+++ b/migrate-to-w3up.test.js
@@ -9,6 +9,9 @@ import { createServer } from 'node:http'
 import { delegate } from '@ucanto/core'
 import { encodeDelegationAsCid } from './w3-env.js'
 import { createMockW3up, spawnMigration } from "./test-utils.js"
+import { text } from 'node:stream/consumers'
+import readNDJSONStream from 'ndjson-readablestream'
+import { Readable } from 'node:stream'
 
 test('uploadsNdJson | migrate-to-w3up --space <space.did>', async () => {
   const defaultCarFinderCarSize = 100
@@ -61,7 +64,7 @@ test('uploadsNdJson | migrate-to-w3up --space <space.did>', async () => {
     const migrationProcess = spawnMigration([
       '--space', spaceA.did(),
       '--ipfs', carFinderUrl.toString(),
-      '--w3up', w3upUrl.toString(), 
+      '--w3up', w3upUrl.toString(),
     ], {
       ...process.env,
       W3_PRINCIPAL: ed25519.format(migrationSession),
@@ -70,44 +73,19 @@ test('uploadsNdJson | migrate-to-w3up --space <space.did>', async () => {
     await pipeline(uploads, migrationProcess.stdin)
     const migrationProcessExit = migrationProcess.exitCode || new Promise((resolve) => migrationProcess.on('exit', () => resolve()))
 
-    const stdoutChunks = []
-    const migrationEvents = []
-    migrationProcess.stdout.on('data', (chunk) => {
-      // console.warn('stdout', chunk.toString())
-      try { migrationEvents.push(JSON.parse(chunk.toString()))} catch (error) { /** pass */ }
-      stdoutChunks.push(chunk)
-    })
-
-    const stderrChunks = []
-    migrationProcess.stderr.on('data', (chunk) => {
-      // console.warn('stderr', chunk.toString())
-      stderrChunks.push(chunk)
-    })
-
-    await migrationProcessExit
+    let stdoutText
+    let stderrText
+    await Promise.all([
+      migrationProcessExit,
+      Promise.resolve().then(async () => {
+        stdoutText = await text(migrationProcess.stdout) }),
+      Promise.resolve().then(async () => {
+        stderrText = await text(migrationProcess.stderr) }),
+    ])
     assert.equal(migrationProcess.exitCode, 0, 'migrationProcess.exitCode is 0 (no error)')
 
-    assert.equal(migrationEvents.length, uploadLimit)
-    const e0 = migrationEvents[0]
-    assert.ok(e0)
-    // each part in original upload appears in event.parts map
-    for (const partCid of e0.upload.parts) {
-      assert.ok(partCid in e0.parts, `event.parts contains key ${partCid}`)
-      const partMigration = e0.parts[partCid]
-      assert.equal(partMigration.part, partCid)
-      assert.deepEqual(partMigration.add.receipt.ran.capabilities[0].nb.link, { '/': partCid })
-      assert.deepEqual(partMigration.add.receipt.out, {
-        ok: {
-          link: { '/': partCid },
-          with: spaceA.did(),
-          status: 'done',
-          allocated: defaultCarFinderCarSize,
-        }
-      })
-    }
-    // event should also have the upload add receipt
-    assert.equal(e0.add.receipt.type, 'Receipt')
-    assert.deepEqual(e0.add.receipt.out.ok.root, {'/': e0.upload.cid})
+    assert.equal(stdoutText, "", 'no stdout')
+    assert.match(stderrText, /migrated 1 upload/, 'stderr reports on how many uploads were migrated')
   }
 
   // servers should listen
@@ -133,142 +111,3 @@ test('uploadsNdJson | migrate-to-w3up --space <space.did>', async () => {
     w3up.close()
   }
 })
-
-/**
- * goal: verify it is possible to migrate uploads and tolerating errors along the way.
- * if one upload errors, the migration should be able to keep going, but keep a record of the failure.
- * after the migration run (with errors logged), the log of uploads that couldn't be migrated is effectively a new migration source.
- */
-test('migrate-to-w3up logs errors', async () => {
-  const defaultCarFinderCarSize = 100
-  const carFinder = createServer(createCarFinder({
-    headers(req) { return { 'content-length': String(defaultCarFinderCarSize) } }
-  }))
-  // mock w3up will error on first store/add but succeed after
-  let didErrorOnFirstStoreAdd = false
-  const w3up = createServer(await createMockW3up({
-    async onHandleStoreAdd(invocation) {
-      if (didErrorOnFirstStoreAdd) {
-        return
-      }
-      didErrorOnFirstStoreAdd = true
-      throw new Error('fake error on first store/add')
-    }
-  }))
-  /**
-   * test with running mock servers
-   * @param {URL} carFinderUrl - url to mock w3s.link gateway, where migration will find cars
-   * @param {URL} w3upUrl - url to mock w3up ucanto http endpoint
-   */
-  async function testMigration(
-    carFinderUrl,
-    w3upUrl,
-  ) {
-    const uploadLimit = 3
-    let uploadsRemaining = uploadLimit
-    const uploads = new ReadableStream({
-      async pull(controller) {
-        if (uploadsRemaining <= 0) {
-          controller.close()
-          return;
-        }
-        const text = JSON.stringify(exampleUpload1) + '\n'
-        const bytes = new TextEncoder().encode(text)
-        controller.enqueue(bytes)
-        uploadsRemaining--
-      }
-    })
-
-    const spaceA = await ed25519.generate()
-    const migrationSession = await ed25519.generate()
-
-    const spaceAAuthorizesMigrationSession = await delegate({
-      issuer: spaceA,
-      audience: migrationSession,
-      capabilities: [
-        {
-          can: 'store/add',
-          with: spaceA.did(),
-        },
-        {
-          can: 'upload/add',
-          with: spaceA.did(),
-        }
-      ]
-    })
-
-    const migrationProcess = spawnMigration([
-      '--space', spaceA.did(),
-      '--ipfs', carFinderUrl.toString(), 
-      '--w3up', w3upUrl.toString(), 
-    ], {
-      ...process.env,
-      W3_PRINCIPAL: ed25519.format(migrationSession),
-      W3_PROOF: (await encodeDelegationAsCid(spaceAAuthorizesMigrationSession)).toString(),
-    })
-    await pipeline(uploads, migrationProcess.stdin)
-    const migrationProcessExit = migrationProcess.exitCode || new Promise((resolve) => migrationProcess.on('exit', () => resolve()))
-
-    const migrationEvents = []
-    migrationProcess.stdout.on('data', (chunk) => {
-      // console.warn('stdout:', chunk.toString())
-      const parsed = JSON.parse(chunk.toString())
-      migrationEvents.push(parsed)
-    })
-
-    const stderrChunks = []
-    migrationProcess.stderr.on('data', (chunk) => {
-      // console.warn('stderr:', chunk.toString())
-      // eslint-disable-next-line no-empty
-      try { migrationEvents.push(JSON.parse(chunk.toString()))} catch {}
-      stderrChunks.push(chunk)
-    })
-
-    await migrationProcessExit
-    assert.equal(migrationProcess.exitCode, 1, 'migrationProcess.exitCode is 1 because not all uploads migrated ok')
-
-    assert.equal(migrationEvents.length, uploadLimit)
-
-    // first event should be a failure
-    const [e0, ...eventsExcludingFirst] = migrationEvents
-    assert.equal(e0.type, 'UploadMigrationFailure')
-    for (const [, partMigration] of Object.entries(e0.parts)) {
-      assert.ok('cause' in partMigration)
-      assert.match(partMigration.cause.message, /fake error on first store\/add/i)
-    }
-    assert.equal(eventsExcludingFirst.length, uploadLimit-1) // -1 to exclude first.
-
-    // remaining events should be success
-    for (const event of eventsExcludingFirst) {
-      assert.equal(event.type, 'UploadMigrationSuccess')
-      assert.deepEqual(event.add.receipt.out.ok, {root:{'/': event.upload.cid}})
-      for (const [partCid, partMigration] of Object.entries(event.parts)) {
-        assert.deepEqual(partMigration.add.receipt.out.ok.link, {'/': partCid})
-      }
-    }
-  }
-
-  // servers should listen
-  await Promise.all([
-    new Promise((resolve, reject) => {
-      carFinder.listen(0)
-      carFinder.on('listening', () => resolve())
-    }),
-    new Promise((resolve, reject) => {
-      w3up.listen(0)
-      w3up.on('listening', () => resolve())
-    }),
-  ])
-  // run tests with urls of running servers,
-  // and ensure servers close when done/error
-  try {
-    await testMigration(
-      locate(carFinder).url,
-      locate(w3up).url,
-    )
-  } finally {
-    carFinder.close()
-    w3up.close()
-  }
-})
-

--- a/migrate-to-w3up.test.js
+++ b/migrate-to-w3up.test.js
@@ -219,9 +219,8 @@ test('migrate-to-w3up logs errors', async () => {
     const stderrChunks = []
     migrationProcess.stderr.on('data', (chunk) => {
       // console.warn('stderr:', chunk.toString())
-      try { migrationEvents.push(JSON.parse(chunk.toString()))} catch {
-        console.warn('error parsing stderr as JSON', chunk.toString())
-      }
+      // eslint-disable-next-line no-empty
+      try { migrationEvents.push(JSON.parse(chunk.toString()))} catch {}
       stderrChunks.push(chunk)
     })
 

--- a/migrate-to-w3up.test.js
+++ b/migrate-to-w3up.test.js
@@ -1,0 +1,222 @@
+import { test } from 'node:test'
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import assert from 'node:assert'
+import { exampleUpload1 } from './w32023.js'
+import * as ed25519 from '@ucanto/principal/ed25519'
+import { ReadableStream } from 'node:stream/web'
+import { pipeline } from 'node:stream/promises'
+import { createCarFinder, locate } from './test-utils.js'
+import { createServer } from 'node:http'
+import * as Server from '@ucanto/server'
+import { Store, Upload } from '@web3-storage/capabilities'
+import * as consumers from 'stream/consumers'
+import * as CAR from '@ucanto/transport/car'
+import { delegate } from '@ucanto/core'
+import { encodeDelegationAsCid } from './w3-env.js'
+
+const migrateToW3upPath = fileURLToPath(new URL('./migrate-to-w3up.js', import.meta.url))
+
+/**
+ * create a RequestListener that can be a mock up.web3.storage
+ */
+async function createMockW3up() {
+  const service = {
+    store: {
+      add: Server.provide(Store.add, async (invocation) => {
+        /** @type {import('@web3-storage/access').StoreAddSuccessDone} */
+        const success = {
+          status: 'done',
+          allocated: invocation.capability.nb.size,
+          link: invocation.capability.nb.link,
+          with: invocation.capability.with,
+        }
+        return {
+          ok: success,
+        }
+      })
+    },
+    upload: {
+      add: Server.provide(Upload.add, async (invocation) => {
+        /** @type {import('@web3-storage/access').UploadAddSuccess} */
+        const success = {
+          root: invocation.capability.nb.root
+        }
+        return {
+          ok: success,
+        }
+      })
+    }
+  }
+  const serverId = (await ed25519.generate()).withDID('did:web:web3.storage')
+  const server = Server.create({
+    id: serverId,
+    service,
+    codec: CAR.inbound,
+    validateAuthorization: () => ({ ok: {} }),
+  })
+  /** @type {import('node:http').RequestListener} */
+  const listener = async (req, res) => {
+    try {
+      const requestBody = new Uint8Array(await consumers.arrayBuffer(req))
+      const response = await server.request({
+        body: requestBody,
+        // @ts-expect-error slight mismatch. ignore like w3infra does
+        headers: req.headers,
+      })
+      res.writeHead(200, response.headers)
+      res.write(response.body)
+    } catch (error) {
+      console.error('error in mock w3up', error)
+      res.writeHead(500)
+      res.write(JSON.stringify(error))
+    } finally {
+      res.end()
+    }
+  }
+  return listener
+}
+
+test('uploadsNdJson | migrate-to-w3up --space <space.did>', async () => {
+  const defaultCarFinderCarSize = 100
+  const carFinder = createServer(createCarFinder({
+    headers(req) { return { 'content-length': String(defaultCarFinderCarSize) } }
+  }))
+  const w3up = createServer(await createMockW3up())
+  /**
+   * test with running mock servers
+   * @param {URL} carFinderUrl - url to mock w3s.link gateway, where migration will find cars
+   * @param {URL} w3upUrl - url to mock w3up ucanto http endpoint
+   */
+  async function testMigration(
+    carFinderUrl,
+    w3upUrl,
+  ) {
+    const uploadLimit = 1
+    let uploadsRemaining = uploadLimit
+    const uploads = new ReadableStream({
+      async pull(controller) {
+        if (uploadsRemaining <= 0) {
+          controller.close()
+          return;
+        }
+        const text = JSON.stringify(exampleUpload1) + '\n'
+        const bytes = new TextEncoder().encode(text)
+        controller.enqueue(bytes)
+        uploadsRemaining--
+      }
+    })
+
+    const spaceA = await ed25519.generate()
+    const migrationSession = await ed25519.generate()
+
+    const spaceAAuthorizesMigrationSession = await delegate({
+      issuer: spaceA,
+      audience: migrationSession,
+      capabilities: [
+        {
+          can: 'store/add',
+          with: spaceA.did(),
+        },
+        {
+          can: 'upload/add',
+          with: spaceA.did(),
+        }
+      ]
+    })
+
+    const migrationProcess = spawnMigration([
+      '--space', spaceA.did(),
+      '--ipfs', carFinderUrl.toString(), 
+      '--w3up', w3upUrl.toString(), 
+    ], {
+      ...process.env,
+      W3_PRINCIPAL: ed25519.format(migrationSession),
+      W3_PROOF: (await encodeDelegationAsCid(spaceAAuthorizesMigrationSession)).toString(),
+    })
+    await pipeline(uploads, migrationProcess.stdin)
+    const migrationProcessExit = migrationProcess.exitCode || new Promise((resolve) => migrationProcess.on('exit', () => resolve()))
+
+    const migrationEvents = []
+    migrationProcess.stdout.on('data', (chunk) => {
+      const parsed = JSON.parse(chunk.toString())
+      migrationEvents.push(parsed)
+    })
+
+    const stderrChunks = []
+    migrationProcess.stderr.on('data', (chunk) => {
+      console.warn(chunk.toString())
+      stderrChunks.push(chunk)
+    })
+
+    await migrationProcessExit
+    assert.equal(migrationProcess.exitCode, 0, 'migrationProcess.exitCode is 0 (no error)')
+
+    assert.equal(migrationEvents.length, uploadLimit)
+    const e0 = migrationEvents[0]
+    assert.ok(e0)
+    // each part in original upload appears in event.parts map
+    for (const partCid of e0.upload.parts) {
+      assert.ok(partCid in e0.parts, `event.parts contains key ${partCid}`)
+      const partMigration = e0.parts[partCid]
+      assert.equal(partMigration.part, partCid)
+      assert.deepEqual(partMigration.add.receipt.ran.capabilities[0].nb.link, { '/': partCid })
+      assert.deepEqual(partMigration.add.receipt.out, {
+        ok: {
+          link: { '/': partCid },
+          with: spaceA.did(),
+          status: 'done',
+          allocated: defaultCarFinderCarSize,
+        }
+      })
+    }
+    // event should also have the upload add receipt
+    assert.equal(e0.add.receipt.type, 'Receipt')
+    assert.deepEqual(e0.add.receipt.out.ok.root, {'/': e0.upload.cid})
+  }
+
+  // servers should listen
+  await Promise.all([
+    new Promise((resolve, reject) => {
+      carFinder.listen(0)
+      carFinder.on('listening', () => resolve())
+    }),
+    new Promise((resolve, reject) => {
+      w3up.listen(0)
+      w3up.on('listening', () => resolve())
+    }),
+  ])
+  // run tests with urls of running servers,
+  // and ensure servers close when done/error
+  try {
+    await testMigration(
+      locate(carFinder).url,
+      locate(w3up).url,
+    )
+  } finally {
+    carFinder.close()
+    w3up.close()
+  }
+})
+
+/**
+ * goal: verify it is possible to migrate uploads and tolerating errors along the way.
+ * if one upload errors, the migration should be able to keep going, but keep a record of the failure.
+ * after the migration run (with errors logged), the log of uploads that couldn't be migrated is effectively a new migration source.
+ */
+// todo
+
+/**
+ * spawn a migrate-to-w3up cli process
+ * @param {string[]} args - cli args
+ * @param {Record<string,string>} env - env vars
+ */
+function spawnMigration(args, env=process.env) {
+  const proc = spawn(migrateToW3upPath, args, {
+    env,
+  })
+  proc.on('error', (error) => {
+    console.error('migration process error event', error)
+  })
+  return proc
+}

--- a/migrate-to-w3up.test.js
+++ b/migrate-to-w3up.test.js
@@ -60,7 +60,7 @@ test('uploadsNdJson | migrate-to-w3up --space <space.did>', async () => {
 
     const migrationProcess = spawnMigration([
       '--space', spaceA.did(),
-      '--ipfs', carFinderUrl.toString(), 
+      '--ipfs', carFinderUrl.toString(),
       '--w3up', w3upUrl.toString(), 
     ], {
       ...process.env,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@web3-storage/pail": "^0.4.0",
         "@web3-storage/w3up-client": "^12.1.0",
         "carstream": "^2.0.0",
+        "inquirer": "^9.2.15",
         "ipfs-unixfs-exporter": "^13.4.0",
         "multiformats": "^13.0.1",
         "ndjson-readablestream": "^1.1.0",
@@ -1106,6 +1107,17 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@ljharb/through": {
+      "version": "2.3.12",
+      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.12.tgz",
+      "integrity": "sha512-ajo/heTlG3QgC8EGP6APIejksVAYt4ayz4tqoP3MolFELzcH1x1fzwEYRJTPO0IELutZ5HQ0c26/GqAYy79u3g==",
+      "dependencies": {
+        "call-bind": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/@multiformats/murmur3": {
@@ -2486,6 +2498,14 @@
         "node": ">= 12"
       }
     },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -2633,6 +2653,17 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.1",
@@ -3747,6 +3778,238 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/inquirer": {
+      "version": "9.2.15",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.15.tgz",
+      "integrity": "sha512-vI2w4zl/mDluHt9YEQ/543VTCwPKWiHzKtm9dM2V0NdFcqEexDAjUHzO1oA60HRNaVifGXXM1tRRNluLVHa0Kg==",
+      "dependencies": {
+        "@ljharb/through": "^2.3.12",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^5.3.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^4.1.0",
+        "external-editor": "^3.1.0",
+        "figures": "^3.2.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "1.0.0",
+        "ora": "^5.4.1",
+        "run-async": "^3.0.0",
+        "rxjs": "^7.8.1",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inquirer/node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/inquirer/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/inquirer/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/interface-blockstore": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-2.0.3.tgz",
@@ -4685,6 +4948,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5055,6 +5323,28 @@
       "version": "1.0.3",
       "resolved": "git+ssh://git@github.com/web3-storage/one-webcrypto.git#5148cd14d5489a8ac4cd38223870e02db15a2382",
       "license": "MIT"
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.3",
@@ -5617,6 +5907,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -5949,6 +6247,11 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
     "node_modules/type": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
@@ -6087,6 +6390,14 @@
       "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
       "dependencies": {
         "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/web-encoding": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@web3-storage/pail": "^0.4.0",
     "@web3-storage/w3up-client": "^12.1.0",
     "carstream": "^2.0.0",
+    "inquirer": "^9.2.15",
     "ipfs-unixfs-exporter": "^13.4.0",
     "multiformats": "^13.0.1",
     "ndjson-readablestream": "^1.1.0",

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,0 +1,45 @@
+import { IncomingMessage } from 'http'
+
+/**
+ * @param {object} options - options
+ * @param {(request: IncomingMessage) => string|undefined} [options.cid] - given request, return a relevant CAR CID to find
+ * @param {(request: IncomingMessage) => Record<string,string>} options.headers - given a request, return map that should be used for http response headers, e.g. to add a content-length header like w3s.link does.
+ * @param {(request: IncomingMessage) => Promise<any>} [options.waitToRespond] - if provided, this can return a promise that can defer responding
+ * @returns {import('http').RequestListener} request listener that mocks w3s.link
+ */
+export function createCarFinder(options) {
+  return (req, res) => {
+    (options.waitToRespond?.(req) ?? Promise.resolve()).then(() => {
+      const getCid = options.cid ?? function (req) {
+        const lastPathSegmentMatch = req.url.match(/\/([^/]+)$/)
+        const cid = lastPathSegmentMatch && lastPathSegmentMatch[1]
+        return cid
+      }
+      const cid = getCid(req)
+      if (!cid) {
+        res.writeHead(404)
+        res.end('cant determine cid');
+        return;
+      }
+      const headers = options.headers(req) ?? {}
+      if (!Object.keys(headers).find(h => h.match(/content-length/i))) {
+        throw new Error('carFinder response headers must include content-length')
+      }
+      res.writeHead(200, {
+        ...headers
+      })
+      res.end()
+    })
+  }
+}
+
+/**
+ * @param {import('http').Server} server - server that should be listening on the returned url
+ */
+export function locate(server) {
+  const address = server.address()
+  if (typeof address === 'string') throw new Error(`unexpected address string`)
+  const { port } = address
+  const url = new URL(`http://localhost:${port}/`)
+  return { url }
+}

--- a/test-utils.js
+++ b/test-utils.js
@@ -105,7 +105,8 @@ export const migrateToW3upPath = fileURLToPath(new URL('./migrate-to-w3up.js', i
 /**
  * create a RequestListener that can be a mock up.web3.storage
  * @param {object} [options] - options
- * @param {(invocation: import('@ucanto/server').ProviderInput<import('@ucanto/client').InferInvokedCapability<typeof Store.add>>) => Promise<void>} [options.onHandleStoreAdd] - store/add handler
+ * @param {(invocation: import('@ucanto/server').ProviderInput<import('@ucanto/client').InferInvokedCapability<typeof Store.add>>) => Promise<void>} [options.onHandleStoreAdd] - called at start of store/add handler
+ * @param {(invocation: import('@ucanto/server').ProviderInput<import('@ucanto/client').InferInvokedCapability<typeof Upload.add>>) => Promise<void>} [options.onHandleUploadAdd] - called at start of upload/add handler
  */
 export async function createMockW3up(options={}) {
   const service = {
@@ -126,6 +127,7 @@ export async function createMockW3up(options={}) {
     },
     upload: {
       add: Server.provide(Upload.add, async (invocation) => {
+        await options.onHandleUploadAdd?.(invocation)
         /** @type {import('@web3-storage/access').UploadAddSuccess} */
         const success = {
           root: invocation.capability.nb.root

--- a/test/migrate-to-w3up-with-logfile.test.js
+++ b/test/migrate-to-w3up-with-logfile.test.js
@@ -28,8 +28,37 @@ async function getTmpLogFilePath() {
 }
 
 await test('running migrate-to-w3up cli with a log file logs to the file passed as --log', async t => {
-  const uploads = createUploadsStream({ limit: 1 })
-  const { carFinder, w3up, close } = await setupMockW3upServices()
+  // we'll migrate three uploads
+  const uploads = createUploadsStream({ limit: 3 })
+  // set things up so the first store/add invocation errors,
+  // but all subsequent store/add invocations dont error.
+  // also the first upload/add invocation will succeed,
+  // but all subsequent ones will error.
+  // For the three migrated uploads, we then expect:
+  // 1. will fail due to underlying store/add error of upload part
+  // 2. will succeed (store/add succeeds after first invocation, and the upload/add will succeed since it should be the first invocation)
+  // 3. will fail due to failure in upload/add invocation
+  let storeAddRequestCount = 0
+  let uploadAddRequestCount = 0
+  const w3upListener = createMockW3up({
+    async onHandleStoreAdd(invocation) {
+      try {
+        if (0===storeAddRequestCount) {
+          throw new Error('mocked store/add error')
+        }
+      } finally {
+        storeAddRequestCount++
+      }
+    },
+    async onHandleUploadAdd(invocation) {
+      uploadAddRequestCount++
+      if (uploadAddRequestCount >= 2) {
+        // error after first request
+        throw new Error('mocked upload/add error')
+      }
+    }
+  })
+  const { carFinder, w3up, close } = await setupMockW3upServices(w3upListener)
   const { space, migrator, migratorCanAddToSpace } = await setupSpaceMigrationScenario()
   const tmpLogFilePath = await getTmpLogFilePath()
   // run test but dont worry about server cleanup
@@ -55,23 +84,40 @@ await test('running migrate-to-w3up cli with a log file logs to the file passed 
       Promise.resolve().then(async () => {
         stderrText = await text(migrationProcess.stderr) }),
     ])
-    assert.equal(migrationProcess.exitCode, 0,
-      'migrationProcess.exitCode is 0 (no error)')
-    // todo reenable
-    // assert.equal(stdoutText, "", 'there should be no stdout because we told it to write to a logfile instead')
-    console.log('stderrText', stderrText)
-    console.log('stdoutText', stdoutText)
-    console.log('tmpLogFilePath', tmpLogFilePath)
+
     const eventsFromLog = []
     for await (const event of readNDJSONStream(Readable.toWeb(createReadStream(tmpLogFilePath)))) {
       eventsFromLog.push(event)
     }
-    console.log('eventsFromLog', eventsFromLog)
-    assert.ok(eventsFromLog.length >= 1, 'log file has at least one object in ndjson')
-    assert.ok(
-      eventsFromLog.find(e => e.type === "UploadMigrationSuccess"),
-      'log has at least one event of type UploadMigrationSuccess'
+
+    assert.ok(eventsFromLog.length >= 1,
+      'log file has at least one object in ndjson')
+    assert.equal(
+      eventsFromLog.filter(e => e.type === "UploadMigrationSuccess").length,
+      1,
+      'log has event of type UploadMigrationSuccess'
     )
+    assert.equal(
+      eventsFromLog.filter(e => e.type === "UploadMigrationFailure").length,
+      2,
+      'log has events of type UploadMigrationFailure'
+    )
+
+    assert.equal(stdoutText, "", 'there should be no stdout because we told it to write to a logfile instead')
+    
+    // stderr should be ndjson
+    const stderrEvents = []
+    for await (const e of readNDJSONStream(Readable.toWeb(Readable.from([new TextEncoder().encode(stderrText)])))) {
+      stderrEvents.push(e)
+      // stderrEvents should only be failures
+      switch (e.type) {
+        case "UploadMigrationFailure":
+          // expected
+          break;
+        default:
+          throw new Error(`unexpected stderr event type ${e.type}`)
+      }
+    }
   }
   try { await run() }
   finally { close(); }
@@ -79,13 +125,14 @@ await test('running migrate-to-w3up cli with a log file logs to the file passed 
 
 /**
  * set up mock http servers that migration depends on: w3up and 'carFinder' e.g. w3s.link gateway
+ * @param {Promise<import('node:http').RequestListener>} w3upListener - mock w3up http request listener
  */
-async function setupMockW3upServices() {
+async function setupMockW3upServices(w3upListener=createMockW3up()) {
   const defaultCarFinderCarSize = 100
   const carFinder = createServer(createCarFinder({
     headers(req) { return { 'content-length': String(defaultCarFinderCarSize) } }
   }))
-  const w3up = createServer(await createMockW3up())
+  const w3up = createServer(await w3upListener)
   const servers = [carFinder, w3up]
   // wait for listening on available port
   await Promise.all(servers.map(async (s) => {

--- a/test/migrate-to-w3up-with-logfile.test.js
+++ b/test/migrate-to-w3up-with-logfile.test.js
@@ -1,0 +1,104 @@
+import { test } from 'node:test'
+import {
+  createMockW3up,
+  spawnMigration,
+  createCarFinder,
+  locate,
+  createUploadsStream,
+  setupSpaceMigrationScenario,
+} from "../test-utils.js"
+import { createServer } from 'node:http'
+import * as ed25519 from '@ucanto/principal/ed25519'
+import { encodeDelegationAsCid } from '../w3-env.js'
+import { pipeline } from 'node:stream/promises'
+import { join } from 'node:path'
+import { text } from 'node:stream/consumers'
+import assert from 'node:assert'
+import { createReadStream } from 'node:fs'
+import * as fs from "fs/promises"
+import { tmpdir } from 'node:os'
+import readNDJSONStream from 'ndjson-readablestream'
+import { Readable } from 'node:stream'
+
+/** make a temporary file path that can be used for test migration logfiles  */
+async function getTmpLogFilePath() {
+  const tmp = await fs.mkdtemp(await fs.realpath(tmpdir()))
+  const path = join(tmp, `migrate-to-w3up-test-${Date.now()}`)
+  return path
+}
+
+await test('running migrate-to-w3up cli with a log file logs to the file passed as --log', async t => {
+  const uploads = createUploadsStream({ limit: 1 })
+  const { carFinder, w3up, close } = await setupMockW3upServices()
+  const { space, migrator, migratorCanAddToSpace } = await setupSpaceMigrationScenario()
+  const tmpLogFilePath = await getTmpLogFilePath()
+  // run test but dont worry about server cleanup
+  const run = async () => {
+    const migrationProcess = spawnMigration([
+      '--space', space.did(),
+      '--ipfs', carFinder.toString(),
+      '--w3up', w3up.toString(),
+      '--log', tmpLogFilePath,
+    ], {
+      ...process.env,
+      W3_PRINCIPAL: ed25519.format(migrator),
+      W3_PROOF: (await encodeDelegationAsCid(migratorCanAddToSpace)).toString(),
+    })
+    await pipeline(uploads, migrationProcess.stdin)
+    const migrationProcessExit = migrationProcess.exitCode || new Promise((resolve) => migrationProcess.on('exit', () => resolve()))
+    let stdoutText
+    let stderrText
+    await Promise.all([
+      migrationProcessExit,
+      Promise.resolve().then(async () => {
+        stdoutText = await text(migrationProcess.stdout) }),
+      Promise.resolve().then(async () => {
+        stderrText = await text(migrationProcess.stderr) }),
+    ])
+    assert.equal(migrationProcess.exitCode, 0,
+      'migrationProcess.exitCode is 0 (no error)')
+    // todo reenable
+    // assert.equal(stdoutText, "", 'there should be no stdout because we told it to write to a logfile instead')
+    console.log('stderrText', stderrText)
+    console.log('stdoutText', stdoutText)
+    console.log('tmpLogFilePath', tmpLogFilePath)
+    const eventsFromLog = []
+    for await (const event of readNDJSONStream(Readable.toWeb(createReadStream(tmpLogFilePath)))) {
+      eventsFromLog.push(event)
+    }
+    console.log('eventsFromLog', eventsFromLog)
+    assert.ok(eventsFromLog.length >= 1, 'log file has at least one object in ndjson')
+    assert.ok(
+      eventsFromLog.find(e => e.type === "UploadMigrationSuccess"),
+      'log has at least one event of type UploadMigrationSuccess'
+    )
+  }
+  try { await run() }
+  finally { close(); }
+})
+
+/**
+ * set up mock http servers that migration depends on: w3up and 'carFinder' e.g. w3s.link gateway
+ */
+async function setupMockW3upServices() {
+  const defaultCarFinderCarSize = 100
+  const carFinder = createServer(createCarFinder({
+    headers(req) { return { 'content-length': String(defaultCarFinderCarSize) } }
+  }))
+  const w3up = createServer(await createMockW3up())
+  const servers = [carFinder, w3up]
+  // wait for listening on available port
+  await Promise.all(servers.map(async (s) => {
+    await new Promise((resolve) => {
+      w3up.on('listening', resolve)
+      s.listen(0)
+    })
+  }))
+  const carFinderUrl = (await locate(carFinder)).url
+  const w3upUrl = (await locate(w3up)).url
+  const close = () => {
+    carFinder.close();
+    w3up.close()
+  }
+  return { carFinder: carFinderUrl, w3up: w3upUrl, close }
+}

--- a/w3-env.js
+++ b/w3-env.js
@@ -1,0 +1,75 @@
+import { CID } from 'multiformats/cid'
+import { identity } from 'multiformats/hashes/identity'
+import { CarReader, CarWriter } from '@ipld/car'
+import { importDAG } from '@ucanto/core/delegation'
+import * as ucanto from '@ucanto/core'
+
+/**
+ * @param {string} proof - proof encoded as CID
+ */
+export async function parseW3Proof(proof) {
+  let cid
+  try {
+    cid = CID.parse(proof)
+  } catch (/** @type {any} */ err) {
+    if (err?.message?.includes('Unexpected end of data')) {
+      console.error(`Error: failed to read proof. The string has been truncated.`)
+    }
+    throw err
+  }
+
+  if (cid.multihash.code !== identity.code) {
+    console.error(`Error: failed to read proof. Must be identity CID. Fetching of remote proof CARs not supported by this command yet`)
+    process.exit(1)
+  }
+  const delegation = await readProofFromBytes(cid.multihash.digest)
+  return delegation
+}
+
+/**
+ * @param {Uint8Array} bytes Path to the proof file.
+ */
+export async function readProofFromBytes(bytes) {
+  const blocks = []
+  try {
+    const reader = await CarReader.fromBytes(bytes)
+    for await (const block of reader.blocks()) {
+      blocks.push(block)
+    }
+  } catch (/** @type {any} */ err) {
+    console.error(`Error: failed to parse proof: ${err.message}`)
+    throw err
+  }
+  try {
+    return importDAG(blocks)
+  } catch (/** @type {any} */ err) {
+    console.error(`Error: failed to import proof: ${err.message}`)
+    throw err
+  }
+}
+
+/**
+ * @param {import('@ucanto/interface').Delegation} delegation - delegation to encode
+ */
+export async function encodeDelegationAsCid(delegation) {
+  const { writer, out } = CarWriter.create()
+  const carChunks = []
+  await Promise.all([
+    // write delegation blocks
+    (async () => {
+      for (const block of delegation.export()) {
+        await writer.put(block)
+      }
+      await writer.close()
+    })(),
+    // read out
+    (async () => {
+      for await (const chunk of out) { carChunks.push(chunk) }
+    })()
+  ])
+  // now get car chunks
+  const car = new Blob(carChunks)
+  const bytes = new Uint8Array(await car.arrayBuffer())
+  const cid = CID.createV1(ucanto.CAR.code, identity.digest(bytes))
+  return cid
+}

--- a/w32023-to-w3up.js
+++ b/w32023-to-w3up.js
@@ -449,7 +449,7 @@ async function transformInvokeUploadAddForMigratedUploadParts({ upload, parts },
     w3up,
   )
   if (!uploadAddReceipt.out.ok) {
-    console.log('uploadAddReceipt.out', uploadAddReceipt.out)
+    console.warn('uploadAddReceipt.out', uploadAddReceipt.out)
     throw new Error(`upload/add failure`)
   }
   const receipt = /** @type {import('@ucanto/interface').Receipt<import("@web3-storage/access").UploadAddSuccess>} */ (

--- a/w32023-to-w3up.test.js
+++ b/w32023-to-w3up.test.js
@@ -9,7 +9,7 @@ import { migrate } from './w32023-to-w3up.js'
 import { createServer } from 'http'
 import { MapCidToPromiseResolvers } from './utils.js'
 import { ReadableStream, TransformStream } from 'stream/web'
-import { MigrateUploadFailure, UploadPartMigrationFailure } from './w3up-migration.js'
+import { UploadMigrationFailure, UploadPartMigrationFailure } from './w3up-migration.js'
 import { createCarFinder, locate } from './test-utils.js'
 
 /** example uploads from `w3 list --json` */
@@ -385,7 +385,7 @@ await test('can migrate in a way that throws when encountering status=upload', a
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const event of migration) {
       migrationEventCount++
-      if (event instanceof MigrateUploadFailure) {
+      if (event instanceof UploadMigrationFailure) {
         failures.push(event)
         break;
       }
@@ -483,7 +483,7 @@ await test('can migrate tolerating store/add invocation errors', async () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for await (const event of migration) {
       migrationEventCount++
-      if (event instanceof MigrateUploadFailure) {
+      if (event instanceof UploadMigrationFailure) {
         failures.push(event)
       }
     }

--- a/w32023.js
+++ b/w32023.js
@@ -80,6 +80,9 @@ export class W32023UploadSummary {
   /** @type {W32023Upload} */
   #upload;
   constructor(upload) {
+    if ( ! upload) {
+      throw new Error(`unexpected falsy upload`)
+    }
     this.#upload = upload
   }
   toJSON() {

--- a/w3up-migration.js
+++ b/w3up-migration.js
@@ -64,6 +64,23 @@ export class MigratedUpload {
 }
 
 /**
+ * @template Upload
+ * @template {Error} [E=Error]
+ * 
+ * a single upload that could not be migrated due to an Error
+ */
+export class UploadPartMigrationFailure {
+  /** @type {import('multiformats').Link} */
+  part
+
+  /** @type {Upload} */
+  upload
+
+  /** @type {E} */
+  cause
+}
+
+/**
  * @param {import('@ucanto/interface').Receipt} r - receipt
  */
 export function receiptToJson(r) {

--- a/w3up-migration.js
+++ b/w3up-migration.js
@@ -1,3 +1,6 @@
+import readNDJSONStream from 'ndjson-readablestream'
+import { ReadableStream } from 'node:stream/web'
+
 /**
  * @template {{ cid: string }} Upload
  * 
@@ -200,4 +203,21 @@ function invocationToJson(i) {
     signature: i.signature,
     expiration: i.expiration,
   }
+}
+
+/**
+ * @param {ReadableStream} readable - readable stream of ndjson migration events
+ * @returns {ReadableStream} - uploads extracted from UploadMigrationFailures in readable
+ */
+export function readUploadsFromUploadMigrationFailuresNdjson(readable) {
+  return new ReadableStream({
+    async start(controller) {
+      for await (const event of readNDJSONStream(readable)) {
+        if (event?.type === 'UploadMigrationFailure') {
+          controller.enqueue(JSON.stringify(event.upload) + '\n')
+        }
+      }
+      controller.close()
+    }
+  })
 }

--- a/w3up-migration.js
+++ b/w3up-migration.js
@@ -6,10 +6,6 @@
  * if the receipt instructed the client to send car bytes, that already happened too
  */
 export class MigratedUploadOnePart {
-  /** @type {Upload} */
-  upload
-  /** @type {string} */
-  part
   /**
    * @type {{
    *   receipt: import('@ucanto/interface').Receipt<import("@web3-storage/access").StoreAddSuccess>
@@ -22,6 +18,10 @@ export class MigratedUploadOnePart {
    * }}
    */
   copy
+  /** @type {string} */
+  part
+  /** @type {Upload} */
+  upload
 }
 
 /**
@@ -29,14 +29,14 @@ export class MigratedUploadOnePart {
  * 
  * a single upload with all blocks migrated to w3up.
  */
-export class MigratedUploadAllParts {
-  /** @type {Upload} */
-  upload
+export class MigratedUploadParts {
   /**
    * map of part CID to migrated part block
    * @type {Map<string, MigratedUploadOnePart<Upload>>}
    */
   parts
+  /** @type {Upload} */
+  upload
 }
 
 /**
@@ -45,10 +45,7 @@ export class MigratedUploadAllParts {
  * a single upload with all blocks migrated to w3up
  * AND an upload/add receipt
  */
-export class MigratedUpload {
-  /** @type {Upload} */
-  upload
-
+export class UploadMigrationSuccess {
   /**
    * @type {{
    *  receipt: import('@ucanto/interface').Receipt<import("@web3-storage/access").UploadAddSuccess>
@@ -61,6 +58,16 @@ export class MigratedUpload {
    * @type {Map<string, MigratedUploadOnePart<Upload>>}
    */
   parts
+
+  /** @type {Upload} */
+  upload
+
+  toJSON() {
+    return {
+      type: 'UploadMigrationSuccess',
+      ...this,
+    }
+  }
 }
 
 /**
@@ -86,10 +93,7 @@ export class UploadPartMigrationFailure {
  * 
  * a single upload that could not be migrated due to an Error
  */
-export class MigrateUploadFailure {
-  /** @type {Upload} */
-  upload
-
+export class UploadMigrationFailure {
   /** @type {E} */
   cause
 
@@ -98,6 +102,16 @@ export class MigrateUploadFailure {
    * @type {Map<string, MigratedUploadOnePart<Upload>|UploadPartMigrationFailure<Upload>>}
    */
   parts
+
+  /** @type {Upload} */
+  upload
+
+  toJSON() {
+    return {
+      type: 'UploadMigrationFailure',
+      ...this,
+    }
+  }
 }
 
 /**

--- a/w3up-migration.js
+++ b/w3up-migration.js
@@ -67,10 +67,10 @@ export class MigratedUpload {
  * @template Upload
  * @template {Error} [E=Error]
  * 
- * a single upload that could not be migrated due to an Error
+ * a single upload *car part* that could not be migrated due to an Error
  */
 export class UploadPartMigrationFailure {
-  /** @type {import('multiformats').Link} */
+  /** @type {string} */
   part
 
   /** @type {Upload} */
@@ -78,6 +78,26 @@ export class UploadPartMigrationFailure {
 
   /** @type {E} */
   cause
+}
+
+/**
+ * @template Upload
+ * @template {Error} [E=Error]
+ * 
+ * a single upload that could not be migrated due to an Error
+ */
+export class MigrateUploadFailure {
+  /** @type {Upload} */
+  upload
+
+  /** @type {E} */
+  cause
+
+  /**
+   * map of part CID to migrated part block (or failure to migrate part)
+   * @type {Map<string, MigratedUploadOnePart<Upload>|UploadPartMigrationFailure<Upload>>}
+   */
+  parts
 }
 
 /**


### PR DESCRIPTION
Motivation:
* when testing https://github.com/web3-storage/migrate-to-w3up/pull/3 , I found that `store/add` invocation sometimes leads to 500 response, and it stops the migration. Yes we could retry, but that could still fail, and I want to take on here being able to run the migration, tolerate inability to migrate a part or whole upload, but keep going and migrate everything else, and just log anything that failed so it can be retried later.

To Do
* [x] migrate() generator can yield more than just successful migrations, but part migration failures too
* [x] probably should wrap part migration failures in a upload migration failure. That way the log is only successfully migrated uploads and failed upload migrations, and inside the latter some parts may have succeeded and some failed
* [x] e2e test that cli migration tolerates errors in store/add invocation
* [x] e2e test that cli migration tolerates errors in upload/add invocation
* [x] e2e test that cli migration can log errors, then use that error log as input to a second migration pass to migrate the errored things